### PR TITLE
Fix/show users on phases of projects

### DIFF
--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -26,4 +26,9 @@ module SchedulesHelper
   def display_tags(user:)
     user.tags.join(', ')
   end
+
+  def project_description(project:)
+    return project.name unless project.phase_name
+    "#{project.name} - #{project.phase_name}"
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,7 +1,8 @@
 class Project
   attr_reader :id,
               :name,
-              :state
+              :state,
+              :phase_name
 
   def initialize(args = {})
     args = args.symbolize_keys if args
@@ -9,6 +10,7 @@ class Project
     @id = args[:id]
     @name = args[:name]
     @state = args[:project_state]
+    @phase_name = args[:phase_name]
   end
 
   # Assignments are passed in because the only way to get

--- a/app/services/project_finder.rb
+++ b/app/services/project_finder.rb
@@ -1,7 +1,8 @@
 class ProjectFinder
   include TenThousandFeetWrapper
   def self.call
-    TenThousandFeetWrapper.client.get_projects(per_page: 500)['data']
-      .map { |project_args| Project.new(project_args) }
+    TenThousandFeetWrapper.client
+                          .get_projects(per_page: 500, with_phases: true)['data']
+                          .map { |project_args| Project.new(project_args) }
   end
 end

--- a/app/views/schedules/_project.html.haml
+++ b/app/views/schedules/_project.html.haml
@@ -1,5 +1,5 @@
 %div.project{ class: project_classes(project: project) }
-  %h2= project.name
+  %h2= project_description(project: project)
   %ul.team-members
     - assignments.each do |assignment|
       - user = users.detect{ |user| user.id == assignment.user_id }

--- a/spec/features/view_daily_schedule_spec.rb
+++ b/spec/features/view_daily_schedule_spec.rb
@@ -118,4 +118,20 @@ RSpec.feature 'View the daily schedule' do
       expect(page).to have_css("li[data-tags='contractor']")
     end
   end
+
+  scenario 'user is on a phase of a project' do
+    allow(client).to receive(:get_projects)
+      .and_return(TenThousandFeetStubs.project_response(project_id: 123, name: 'a-project-name', phase_name: 'alpha'))
+    allow(client).to receive(:get_assignments)
+      .and_return(TenThousandFeetStubs.assignment_response(project_id: 123, user_id: 'user-id'))
+    allow(client).to receive(:get_users)
+      .and_return(TenThousandFeetStubs.user_response(user_id: 'user-id', first_name: 'first-name'))
+
+    visit root_path
+
+    within('.a-project-name') do
+      expect(page).to have_content('a-project-name - alpha')
+      expect(page).to have_content('first-name')
+    end
+  end
 end

--- a/spec/helpers/schedules_helper_spec.rb
+++ b/spec/helpers/schedules_helper_spec.rb
@@ -92,4 +92,18 @@ RSpec.describe SchedulesHelper, type: :helper do
       end
     end
   end
+
+  describe 'project_description' do
+    it 'returns the name of the project' do
+      result = project_description(project: Project.new(name: 'foo'))
+      expect(result).to eq('foo')
+    end
+
+    context 'when the project is a phase (child project)' do
+      it 'returns both name and child name' do
+        result = project_description(project: Project.new(name: 'baz', phase_name: 'bar'))
+        expect(result).to eq('baz - bar')
+      end
+    end
+  end
 end

--- a/spec/services/project_finder_spec.rb
+++ b/spec/services/project_finder_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe ProjectFinder, type: :service do
     end
 
     it 'requests all projects by default' do
-      expect(client).to receive(:get_projects).with(per_page: 500)
+      expect(client).to receive(:get_projects).with(a_hash_including(per_page: 500))
+      described_class.call
+    end
+
+    it 'requests all phases (children of projects) by default' do
+      expect(client).to receive(:get_projects).with(a_hash_including(with_phases: true))
       described_class.call
     end
 

--- a/spec/support/ten_thousand_feet_stubs.rb
+++ b/spec/support/ten_thousand_feet_stubs.rb
@@ -73,7 +73,7 @@ module TenThousandFeetStubs
      "data"=>[]}
    end
 
-  def self.project_response(project_id: 8370190, name: 'NHS')
+  def self.project_response(project_id: 8370190, name: 'NHS', phase_name: nil)
     {"paging"=>
       {"per_page"=>20,
        "page"=>1,
@@ -89,7 +89,7 @@ module TenThousandFeetStubs
         "guid"=>"45354fc3-c379-4b61-bd12-5934f7d04796",
         "name"=>name,
         "parent_id"=>nil,
-        "phase_name"=>nil,
+        "phase_name"=>phase_name,
         "project_code"=>"",
         "secureurl"=>nil,
         "secureurl_expiration"=>nil,


### PR DESCRIPTION
Let's say we had a project `NHS Intranet` with a single person assigned to it, they appear as normal on the dashboard. 

When in 10kft that project is broken up into phases (sub projects) this phase is given a new `id` and the person disappears completely! This happened because the assignment which had the right project ID was unable to find a matching project in our list of projects. This PR makes sure our person shows up under the project `NHS Intranet - <phase>`.

