### PR TITLE
(feature): Display anytype of leave type

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -33,8 +33,7 @@
   -webkit-box-ordinal-group: 0;
 }
 
-.holiday,
-.sick {
+.leave {
   -moz-order: 100;
   -ms-order: 100;
   -o-order: 100;
@@ -76,14 +75,12 @@
   background-color: $internal;
 }
 
-.project.holiday,
-.project.sick {
+.project.leave {
   border-color: $leave;
   background-color: $leave_with_alpha;
 }
 
-.project.holiday h2,
-.project.sick h2 {
+.project.leave h2 {
   background-color: $leave;
 }
 

--- a/app/facades/today_schedule_facade.rb
+++ b/app/facades/today_schedule_facade.rb
@@ -15,16 +15,15 @@ class TodayScheduleFacade
     @leave_types ||= LeaveTypeFinder.call
   end
 
-  def holiday_assignments
-    holiday = leave_types.detect{ |leave_type| leave_type.name.eql?('Holiday') }
-    return [] unless holiday
-    @holiday_assignments ||= todays_assignments.select{ |assignment| holiday.id == assignment.project_id }
-  end
+  def ooo_assignments
+    return [] unless leave_types
 
-  def sick_assignments
-    sick = leave_types.detect{ |leave_type| leave_type.name.eql?('Sick') }
-    return [] unless sick
-    @sick_assignments ||= todays_assignments.select{ |assignment| sick.id == assignment.project_id }
+    leave_types.inject({}) do |assignments, leave_type|
+      matching_assignments = todays_assignments.select { |assignment| leave_type.id == assignment.project_id }
+      next assignments if matching_assignments.empty?
+
+      assignments.merge!(leave_type.name => matching_assignments)
+    end
   end
 
   def users_without_assignments

--- a/app/views/schedules/index.html.haml
+++ b/app/views/schedules/index.html.haml
@@ -10,11 +10,8 @@
         - if project_assignments.present?
           = render 'project', project: project, assignments: project_assignments, users: @schedule.users
 
-    - if @schedule.holiday_assignments.present?
-      = render 'project', project: Project.new(name: 'Holiday', project_state: 'leave'), assignments: @schedule.holiday_assignments, users: @schedule.users
-
-    - if @schedule.sick_assignments.present?
-      = render 'project', project: Project.new(name: 'Sick', project_state: 'leave'), assignments: @schedule.sick_assignments, users: @schedule.users
+    - @schedule.ooo_assignments.each_pair do |ooo_name, assignments|
+      = render 'project', project: Project.new(name: ooo_name, project_state: 'leave'), assignments: assignments, users: @schedule.users
 
     - if @schedule.users_without_assignments.present?
       = render 'unassigned_users', users: @schedule.users_without_assignments

--- a/spec/facades/today_schedule_facade_spec.rb
+++ b/spec/facades/today_schedule_facade_spec.rb
@@ -56,27 +56,27 @@ RSpec.describe TodayScheduleFacade, type: :facade do
     end
   end
 
-  describe '#holiday_assignments' do
-    it 'returns only the assignments for the holiday leave type' do
+  describe '#ooo_assignments' do
+    it 'returns only the assignments for the given leave type' do
       holiday_leave_type = LeaveType.new(id: 123, name: 'Holiday')
       allow(LeaveTypeFinder).to receive(:call).and_return([holiday_leave_type])
 
       holiday_assignment = Assignment.new(project_id: 123)
       stub_assignment_finder(assignments: [holiday_assignment])
 
-      result = described_class.new.holiday_assignments
+      result = described_class.new.ooo_assignments
 
       expect(result.count).to eq(1)
-      expect(result.first).to eq(holiday_assignment)
+      expect(result.first).to eq(['Holiday', [holiday_assignment]])
     end
 
     context 'when there is no leave type' do
       it 'returns an empty array' do
         allow(LeaveTypeFinder).to receive(:call).and_return([])
 
-        result = described_class.new.holiday_assignments
+        result = described_class.new.ooo_assignments
 
-        expect(result).to eq([])
+        expect(result).to eq({})
       end
     end
 
@@ -86,46 +86,9 @@ RSpec.describe TodayScheduleFacade, type: :facade do
         allow(LeaveTypeFinder).to receive(:call).and_return([holiday_leave_type])
         stub_assignment_finder(assignments: [])
 
-        result = described_class.new.holiday_assignments
+        result = described_class.new.ooo_assignments
 
-        expect(result).to eq([])
-      end
-    end
-  end
-
-  describe '#sick_assignments' do
-    it 'returns only the assignments for the holiday leave type' do
-      sick_leave_type = LeaveType.new(id: 123, name: 'Sick')
-      allow(LeaveTypeFinder).to receive(:call).and_return([sick_leave_type])
-
-      sick_assignment = Assignment.new(project_id: 123)
-      stub_assignment_finder(assignments: [sick_assignment])
-
-      result = described_class.new.sick_assignments
-
-      expect(result.count).to eq(1)
-      expect(result.first).to eq(sick_assignment)
-    end
-
-    context 'when there is no leave type' do
-      it 'returns an empty array' do
-        allow(LeaveTypeFinder).to receive(:call).and_return([])
-
-        result = described_class.new.sick_assignments
-
-        expect(result).to eq([])
-      end
-    end
-
-    context 'when there are no assignments to holiday' do
-      it 'returns an empty array' do
-        sick_leave_type = LeaveType.new(id: 123, name: 'Sick')
-        allow(LeaveTypeFinder).to receive(:call).and_return([sick_leave_type])
-        stub_assignment_finder(assignments: [])
-
-        result = described_class.new.sick_assignments
-
-        expect(result).to eq([])
+        expect(result).to eq({})
       end
     end
   end

--- a/spec/features/view_daily_schedule_spec.rb
+++ b/spec/features/view_daily_schedule_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature 'View the daily schedule' do
 
     visit root_path
 
-    within('.sick') do
+    within('.leave') do
       expect(page).to have_content('Sick')
       expect(page).to have_content('first-name')
     end


### PR DESCRIPTION
* not just the very specific leave types named: ‘Sick’ and ‘Holiday’ which limited us when we wanted to change to a new name: 'Out of office'
* I started out thinking this should be configurable through the environment but in the end I saw no reason no just to display all leave types with assignments on a given day and have this dynamic. This makes the app slightly simpler too 👍 

![screen shot 2018-02-16 at 14 58 27](https://user-images.githubusercontent.com/912473/36313613-ee8e8518-1329-11e8-9ae3-df90594e70ce.png)
