### PR TITLE
People named Chris are disambiguated

### DIFF
--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -12,6 +12,10 @@ module SchedulesHelper
 
   def nickname(user:)
     case user.id
+    when 478731 then 'chris l'
+    when 472497 then 'chris p'
+    when 478728 then 'chris r'
+    when 389584 then 'chris w'
     when 387517 then 'hippers'
     when 389616 then 'leeky'
     when 389599 then 'leanne c'


### PR DESCRIPTION
We currently have four people with the forename Chris
who can appear on the dashboard, two permanent employees
and two contractors.

This commit adds them to the nickname helper with forename
and first letter of surname.