### PR TITLE
(fix) Security update for Loofah 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'coffee-rails', '~> 4.2'
 gem 'jbuilder', '~> 2.5'
 gem 'ten_thousand_feet'
 gem 'nokogiri', '~> 1.8.2' # CVE-2017-18258
-gem 'loofah', '~> 2.2.1' # CVE-2018-8048
+gem 'loofah', '>= 2.2.3' # CVE-2018-16468 
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -129,7 +129,7 @@ GEM
     multi_json (1.12.2)
     netrc (0.11.0)
     nio4r (2.1.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.0)
     parser (2.4.0.2)
@@ -286,7 +286,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen (>= 3.0.5, < 3.2)
-  loofah (~> 2.2.1)
+  loofah (>= 2.2.3)
   nokogiri (~> 1.8.2)
   pry-rails
   pry-rescue


### PR DESCRIPTION
* https://nvd.nist.gov/vuln/detail/CVE-2018-16468
* The gem we use which this is a depedency of is https://github.com/rails/rails-html-sanitizer which doesn’t have an upgrade, so we have to go and update this gem explicitly.