### PR TITLE
Client can authenticate with auth_token

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,4 +1,14 @@
 class SchedulesController < ApplicationController
+
+  before_action :check_we_can_login
+
+  def check_we_can_login
+    if error = TenkftClientWrapper.client.error_message
+      flash[:error] = error
+      render 'layouts/application'
+    end
+  end
+
   def index
     @schedule = TodayScheduleFacade.new
   end

--- a/spec/features/view_daily_schedule_spec.rb
+++ b/spec/features/view_daily_schedule_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'View the daily schedule' do
-  let(:client) { double }
+  let(:client) { double(error_message: nil) }
   before(:each) do
     stub_ten_thousand_feet_client(client: client)
     stub_ten_thousand_feet_project_response(client: client)


### PR DESCRIPTION
Recently, our requests started failing with the response ‘Bad request’.

The client now checks for the presence of an auth token, in addition to a cookie, and preferentially uses the token to send requests.

If neither token nor cookie are available, fail more gracefully and informatively.