### PR TITLE
(Fix) Route53 resource name

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_record" "10kft-scheduling" {
+resource "aws_route53_record" "tenkft-scheduling" {
   zone_id = "${data.aws_route53_zone.infrastructure_root_domain_zone.zone_id}"
   name    = "10kft-scheduling-dashboard.${var.environment}.${var.infrastructure_name}.${var.root_domain_zone}."
   type    = "CNAME"


### PR DESCRIPTION
* Resource names can't begin with a number