### PR TITLE
(Chore) Add's a `/check` route which returns 200

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   root 'schedules#index'
+
+  get "/check", to: proc { [200, {}, ["OK"]] }
 end

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'Health Check', type: :request do
+  it 'returns an ok http code' do
+    get '/check', headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
+
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
* This is needed for the AWS loadbalancer, which pings `/check` to see
if the container is alive