### PR TITLE
(fix) Reconfigure logging for Dalmatian

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,11 +66,9 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
+  logger           = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger    = ActiveSupport::TaggedLogging.new(logger)
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
We have recently deployed this app to Dalmatian for the first time.
Chris noticed that there are no request logs for the Dalmatian app in
Papertrail.

In production, we want the app to log to the container's output so that
the log output can be collected and uploaded to Papertrail.

Currently, the app only logs to STDOUT if RAILS_LOG_TO_STDOUT is set in
the environment, which it is not. Since we _always_ want to log to
STDOUT in production, just remove this check.